### PR TITLE
readded german "umlaute" to allowed characters

### DIFF
--- a/src/main/java/net/cubespace/geSuitHomes/commands/SetHomeCommand.java
+++ b/src/main/java/net/cubespace/geSuitHomes/commands/SetHomeCommand.java
@@ -19,7 +19,7 @@ public class SetHomeCommand implements CommandExecutor {
 		if(args.length==0){
 			HomesManager.setHome(sender, "home");
 		}else{
-			Pattern invalidChar = Pattern.compile("[^a-zA-Z0-9_äöüßÄÖÜ]");
+			Pattern invalidChar = Pattern.compile("[^a-zA-Z0-9_äöüßÄÖÜ-]");
 			Matcher reMatch = invalidChar.matcher(args[0]);
 
 			StringBuffer bufstr = new StringBuffer();

--- a/src/main/java/net/cubespace/geSuitHomes/commands/SetHomeCommand.java
+++ b/src/main/java/net/cubespace/geSuitHomes/commands/SetHomeCommand.java
@@ -19,7 +19,7 @@ public class SetHomeCommand implements CommandExecutor {
 		if(args.length==0){
 			HomesManager.setHome(sender, "home");
 		}else{
-			Pattern invalidChar = Pattern.compile("[^a-zA-Z0-9_-]");
+			Pattern invalidChar = Pattern.compile("[^a-zA-Z0-9_äöüßÄÖÜ]");
 			Matcher reMatch = invalidChar.matcher(args[0]);
 
 			StringBuffer bufstr = new StringBuffer();


### PR DESCRIPTION
"umlaute" are quite common in germany so many users are using these characters in their home names and this is working quite well.
So I readded them to the allowed characters.

I may broke the regex as I didn't know where to place the "-" (That was behind "_")
For now I put it to the end. If this is wrong you can just replace it in your own code and push it.

I think there are other utf8 characters in other languages that are working as well, so this regex is not the best solution...
However I don't know a better solution.
